### PR TITLE
Handle single & double quote

### DIFF
--- a/lib/extractors/hbs.js
+++ b/lib/extractors/hbs.js
@@ -41,7 +41,7 @@ function handle_mustache(mustache, opts, nodes) {
     if ((mustache.id.type === 'ID')
         && (mustache.id.string === opts.keyword || mustache.id.string.indexOf(opts.keyword + '.') === 0)
         && mustache.params.length >= 1) {
-        var node = {line: mustache.firstLine, src: make_function(mustache.id, mustache.params)};
+        var node = {line: mustache.firstLine, src: make_function(mustache.id, mustache.params, opts)};
         nodes.push(node);
     }
 
@@ -52,12 +52,12 @@ function handle_mustache(mustache, opts, nodes) {
 }
 
 
-function make_function(id, params) {
+function make_function(id, params, opts) {
     var buff = id.string + '(';
 
     buff += params.map(function(p) {
         if (p.type === 'STRING') {
-            var quote = _get_delimiter_quote(p.string);
+            var quote = _get_delimiter_quote(p, opts);
             return quote + p.string + quote;
         }
         return 0;
@@ -69,12 +69,14 @@ function make_function(id, params) {
 }
 
 
-function _get_delimiter_quote(param_str) {
-    var contains_double = param_str.indexOf('"') !== -1;
-    var contains_single = param_str.indexOf("'") !== -1;
+function _get_delimiter_quote(param, opts) {
+    var contains_double = param.string.indexOf('"') !== -1;
+    var contains_single = param.string.indexOf("'") !== -1;
     // I can not think of a use case where both get mixed up but he...
     if (contains_double && contains_single) {
-        throw new Error('Your gettext string can not contains both single & double quote.');
+        var msg = 'On line ' + param.firstLine + ' column ' + param.firstColumn + ' of file ' + opts.filename + '.\n';
+            msg += 'Your gettext string can not contains both single & double quote.';
+        throw new Error(msg);
     }
 
     return contains_double ? "'" : '"';

--- a/test/extractors/hbs.test.js
+++ b/test/extractors/hbs.test.js
@@ -381,6 +381,18 @@ describe("jspot.extractors:hbs", function() {
             );
         });
 
+        it("throws an error if contains double & single quoted parameters", function() {
+            assert.throws(function() {
+                extractor({
+                    filename: 'foo.js',
+                    source: [
+                        "<div>{{gettext \"<span id=\\\"id\\\" class='bold'>foo</span>\" }}</div>",
+                    ].join('\n')
+                });
+            },
+            'On line 1 column 15 of file foo.js.\nYour gettext string can not contains both single & double quote.');
+        });
+
         it("should work inside a complicated statement", function() {
             assert.deepEqual(
                 extractor({


### PR DESCRIPTION
Should fix issue #27

This issue comes when in handlebars you have this kind of thing

``` handlebars
{{{sprintf (gettext '<span class="counter">%s</span> foo' '<span class="counter">%s</span> foos' much) much }}}
```

It's a weird case where HTML is included in string to translate because you want another typo or font size for the variable but in a big long sentence. As you want to preserve localization, because in some other language the variable can be set in another place in the sentence, you include it in the sentence to translate.

So... double quote in the sentence...

And the hbs extractors transforms it to JS like function before calling execution in gettext context

``` javascript
gettext("<span class="counter">%s</span> foo", "<span class="counter">%s</span> foos", 0)
```

See how double quote ruins everything.

This PR fixes it by choosing which quote to use, single or double.
