### PR TITLE
Allow external extractors to be plugged in via the cli

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var _ = require('underscore');
+var path = require('path');
 var jspot = require('./');
 var cli = module.exports = require('nomnom');
 
@@ -34,6 +35,12 @@ cli
         metavar: 'NAME:VALUE',
         list: true,
         help: 'Set a header for the written pot files'
+    })
+    .option('extractor', {
+      abbr: 'e',
+      metavar: 'EXTENSION:MODULE',
+      list: true,
+      help: 'Add a custom extractor'
     });
 
 
@@ -61,6 +68,21 @@ function extract(opts) {
         headers[name] = header.slice(name.length + 1);
         return headers;
     }, {});
+
+    (opts.extractor || []).forEach(function(e) {
+        var pair = e.split(':');
+        var ending = pair[0];
+        var module_name = pair[1];
+        var extractor;
+
+        try {
+            extractor = require(module_name);
+        } catch (e) {
+            extractor = require(path.resolve(module_name));
+        }
+
+        jspot.extractors.support(ending, extractor);
+    });
 
     jspot.extract(opts);
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,7 +1,9 @@
 var _ = require('underscore');
 var path = require('path');
 
+var jspot = require('../lib');
 var cli = require('../lib/cli');
+var extract_js = require('../lib/extractors/js');
 var helpers = require('./helpers');
 
 
@@ -95,6 +97,37 @@ describe('cli', function() {
             helpers.assert_files_equal(
                 path.join(tmpdir, 'messages.pot'),
                 './test/fixtures/extract/headers/output/messages.pot');
+        });
+
+        it("should support custom extractors", function() {
+            cli.parse([
+                'extract',
+                '-t', tmpdir,
+                '-e', 'txt:./test/fixtures/extract/extractors/input/jspot-txt',
+                './test/fixtures/extract/extractors/input/a.txt',
+                './test/fixtures/extract/extractors/input/b.txt',
+            ]);
+
+            helpers.assert_files_equal(
+                path.join(tmpdir, 'messages.pot'),
+                './test/fixtures/extract/extractors/output/messages.pot');
+        });
+
+        it("should allow custom extractors to override builtins", function() {
+            cli.parse([
+                'extract',
+                '-t', tmpdir,
+                '-e',
+                'js:./test/fixtures/extract/extractors-override/input/jspot-js',
+                './test/fixtures/extract/extractors-override/input/a.js',
+            ]);
+
+            helpers.assert_files_equal(
+                path.join(tmpdir, 'messages.pot'),
+                './test/fixtures/extract/extractors-override/output/messages.pot');
+
+            // restore the original extractor
+            jspot.extractors.support('js', extract_js);
         });
     });
 

--- a/test/fixtures/extract/extractors-override/input/a.js
+++ b/test/fixtures/extract/extractors-override/input/a.js
@@ -1,0 +1,1 @@
+gettext('hello');

--- a/test/fixtures/extract/extractors-override/input/jspot-js.js
+++ b/test/fixtures/extract/extractors-override/input/jspot-js.js
@@ -1,0 +1,15 @@
+var _extract = require('lib/extractors/js');
+
+
+function extract(opts) {
+    var results = _extract(opts);
+
+    results.forEach(function(d) {
+        d.key += '!';
+    });
+
+    return results;
+}
+
+
+module.exports = extract;

--- a/test/fixtures/extract/extractors-override/input/jspot-js.js
+++ b/test/fixtures/extract/extractors-override/input/jspot-js.js
@@ -1,4 +1,4 @@
-var _extract = require('./lib/extractors/js');
+var _extract = require('../../../../../lib/extractors/js');
 
 
 function extract(opts) {

--- a/test/fixtures/extract/extractors-override/input/jspot-js.js
+++ b/test/fixtures/extract/extractors-override/input/jspot-js.js
@@ -1,4 +1,4 @@
-var _extract = require('lib/extractors/js');
+var _extract = require('./lib/extractors/js');
 
 
 function extract(opts) {

--- a/test/fixtures/extract/extractors-override/output/messages.pot
+++ b/test/fixtures/extract/extractors-override/output/messages.pot
@@ -1,0 +1,14 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2014-02-25 10:58:+0000\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+
+#: ./test/fixtures/extract/extractors-override/input/a.js:1
+msgid "hello!"
+msgstr ""

--- a/test/fixtures/extract/extractors/input/a.txt
+++ b/test/fixtures/extract/extractors/input/a.txt
@@ -1,0 +1,1 @@
+gettext hello

--- a/test/fixtures/extract/extractors/input/b.txt
+++ b/test/fixtures/extract/extractors/input/b.txt
@@ -1,0 +1,1 @@
+gettext goodbye

--- a/test/fixtures/extract/extractors/input/jspot-txt.js
+++ b/test/fixtures/extract/extractors/input/jspot-txt.js
@@ -1,0 +1,26 @@
+function extract(opts) {
+    return opts.source
+        .split('\n')
+        .reduce(function(results, line, i) {
+            if (!line.length) return results;
+
+            var lineResults = line
+                .match(/gettext .*/g)
+                .map(function(v) {
+                    return {
+                        key: v.substring('gettext '.length),
+                        plural: null,
+                        domain: 'messages',
+                        context: '',
+                        category: null,
+                        line: i + 1,
+                        filename: opts.filename
+                    };
+                });
+
+            return results.concat(lineResults);
+        }, []);
+}
+
+
+module.exports = extract;

--- a/test/fixtures/extract/extractors/output/messages.pot
+++ b/test/fixtures/extract/extractors/output/messages.pot
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2014-02-25 10:58:+0000\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+
+#: ./test/fixtures/extract/extractors/input/a.txt:1
+msgid "hello"
+msgstr ""
+
+#: ./test/fixtures/extract/extractors/input/b.txt:1
+msgid "goodbye"
+msgstr ""


### PR DESCRIPTION
From the discussion on #11, the plan is to allow external extractors to be plugged in via the cli. The command might look something like:

```
$ jspot extract foo.html bar.jst baz.js quux.hbs -e html:hbs -e jst:jspot-jst
```

We could maybe have each `-e` first look for a bundled extractor (which I'd like to keep to just `js` and `hbs`, at least for now), and fall back to trying to require a module name (in the example above, `jspot-jst`). 