### PR TITLE
Update hbs parser & jspot hbs extractor to 3.0.0

### DIFF
--- a/lib/extractors/hbs.js
+++ b/lib/extractors/hbs.js
@@ -18,7 +18,7 @@ function extract(opts) {
 
 function gather(src, opts) {
     var nodes = [];
-    handle_statements(hbs.parse(src).statements, opts, nodes);
+    handle_statements(hbs.parse(src).body, opts, nodes);
 
     return nodes;
 }
@@ -26,14 +26,14 @@ function gather(src, opts) {
 
 function handle_statements(statements, opts, nodes) {
     statements.forEach(function(statement) {
-        if (statement.type === 'mustache' || statement.type === 'sexpr') {
+        if (statement.type === 'MustacheStatement' || statement.type === 'SubExpression') {
             handle_mustache(statement, opts, nodes);
 
-        } else if (statement.type === 'block') {
-            handle_statements(statement.program.statements, opts, nodes);
+        } else if (statement.type === 'BlockStatement') {
+            handle_statements(statement.program.body, opts, nodes);
 
-            if (statement.program.inverse) {
-                handle_statements(statement.program.inverse.statements, opts, nodes);
+            if (statement.inverse) {
+                handle_statements(statement.inverse.body, opts, nodes);
             }
         }
     });
@@ -41,30 +41,30 @@ function handle_statements(statements, opts, nodes) {
 
 
 function handle_mustache(mustache, opts, nodes) {
-    // if statement is type 'ID' (helper) &&
+    // if statement path type 'PathExpression' (helper) &&
     // if mustache statement is for gettext or gettext.xxx &&
     // has params
-    if ((mustache.id.type === 'ID')
-        && (mustache.id.string === opts.keyword || mustache.id.string.indexOf(opts.keyword + opts.hbs.separator) === 0)
+    if (mustache.path.type === 'PathExpression'
+        && (mustache.path.original === opts.keyword || mustache.path.original.indexOf(opts.keyword + opts.hbs.separator) === 0)
         && mustache.params.length >= 1) {
-        var node = {line: mustache.firstLine, src: make_function(mustache.id, mustache.params, opts)};
+        var node = {line: mustache.loc.start.line, src: make_function(mustache.path, mustache.params, opts)};
         nodes.push(node);
     }
 
     // recursive call for sub expression
-    if (mustache.sexpr) {
-        mustache.sexpr.params.forEach(function(statement) { handle_statements([statement], opts, nodes); });
-    }
+    handle_statements(mustache.params.filter(function(param) {
+        return param.type === 'SubExpression';
+    }), opts, nodes);
 }
 
 
-function make_function(id, params, opts) {
-    var buff = id.string === opts.keyword ? id.string : id.string.replace(opts.keyword + opts.hbs.separator, opts.keyword + '.');
+function make_function(path, params, opts) {
+    var buff = path.original === opts.keyword ? path.original : path.original.replace(opts.keyword + opts.hbs.separator, opts.keyword + '.');
     buff +=  '(';
     buff += params.map(function(p) {
-        if (p.type === 'STRING') {
+        if (p.type === 'StringLiteral') {
             var quote = _get_delimiter_quote(p, opts);
-            return quote + p.string + quote;
+            return quote + p.value + quote;
         }
         return 0;
     }).join(', ');
@@ -75,11 +75,11 @@ function make_function(id, params, opts) {
 
 
 function _get_delimiter_quote(param, opts) {
-    var contains_double = param.string.indexOf('"') !== -1;
-    var contains_single = param.string.indexOf("'") !== -1;
+    var contains_double = param.value.indexOf('"') !== -1;
+    var contains_single = param.value.indexOf("'") !== -1;
     // I can not think of a use case where both get mixed up but he...
     if (contains_double && contains_single) {
-        var msg = 'On line ' + param.firstLine + ' column ' + param.firstColumn + ' of file ' + opts.filename + '.\n';
+        var msg = 'On line ' + param.loc.start.line + ' column ' + param.loc.start.column + ' of file ' + opts.filename + '.\n';
             msg += 'Your gettext string can not contains both single & double quote.';
         throw new Error(msg);
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "falafel": "~0.3.1",
     "gettext-parser": "~0.2.0",
-    "handlebars": "~1.3.0",
+    "handlebars": "^3.0.0",
     "moment": "~2.5.1",
     "nomnom": "~1.6.2",
     "po2json": "~0.2.3",


### PR DESCRIPTION
Handlebars 2 & 3 came with new parser. The new AST is sooooo much cleaner and easy to read and support new hbs 3.0.0.

Fixes #34