### PR TITLE
Doesn't work with files containing ES2015 code.

### DIFF
--- a/lib/extractors/js.js
+++ b/lib/extractors/js.js
@@ -1,6 +1,18 @@
+var _ = require('underscore');
 var vm = require('vm');
 var falafel = require('falafel');
 var gettext = require('../gettext');
+
+
+function transform(src, opts, fn) {
+    if (typeof opts == 'function')  {
+        fn = opts;
+        opts = {};
+    }
+
+    opts = _.extend({ecmaVersion: 6}, opts);
+    return falafel(src, opts, fn);
+}
 
 
 function extract(opts) {
@@ -13,7 +25,7 @@ function extract(opts) {
 
 
 function yoink_members(src, opts) {
-    return falafel(src, function(node) {
+    return transform(src, function(node) {
         if (is_member(node, opts)) {
             node.parent.update(node.source());
         }
@@ -24,7 +36,7 @@ function yoink_members(src, opts) {
 function gather(src, opts) {
     var matches = [];
 
-    falafel(src, {loc: true}, function(node) {
+    transform(src, {locations: true}, function(node) {
         if (match(node, opts)) {
             matches.push(parse(node, opts));
         }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/praekelt/jspot/issues"
   },
   "dependencies": {
-    "falafel": "~0.3.1",
+    "falafel": "~1.2",
     "gettext-parser": "~0.2.0",
     "handlebars": "^3.0.0",
     "moment": "~2.5.1",

--- a/test/extractors/js.test.js
+++ b/test/extractors/js.test.js
@@ -155,6 +155,23 @@ describe("jspot.extractors:js", function() {
             }]);
     });
 
+    it("should work with es2015 syntax", function() {
+        assert.deepEqual(
+            extractor({
+                filename: 'foo.js',
+                source: "class Foo {bar() { gettext('baz'); }}"
+            }),
+            [{
+                key: 'baz',
+                plural: null,
+                domain: 'messages',
+                context: '',
+                category: null,
+                line: 1,
+                filename: 'foo.js'
+            }]);
+    });
+
     describe("gettext", function() {
         it("should extract member calls", function() {
             assert.deepEqual(


### PR DESCRIPTION
How is it that JSPot actually scans source files? I've found that I need to keep them all within a single JS "lookup" file that uses no ES2015 code because the parser errors out when it hits keywords like "Class" and so on.

Any ideas how feasible it would be to upgrade this project to work with the latest standard of JavaScript, and if not, do you know of any similar projects to JSPot?