### PR TITLE
Ensuring users can truly pass options to transform.

### DIFF
--- a/lib/extractors/js.js
+++ b/lib/extractors/js.js
@@ -25,7 +25,9 @@ function extract(opts) {
 
 
 function yoink_members(src, opts) {
-    return transform(src, function(node) {
+    opts = _.extend({}, opts);
+
+    return transform(src, opts, function(node) {
         if (is_member(node, opts)) {
             node.parent.update(node.source());
         }
@@ -36,7 +38,9 @@ function yoink_members(src, opts) {
 function gather(src, opts) {
     var matches = [];
 
-    transform(src, {locations: true}, function(node) {
+    opts = _.extend({}, { locations: true }, opts);
+
+    transform(src, opts, function(node) {
         if (match(node, opts)) {
             matches.push(parse(node, opts));
         }

--- a/lib/extractors/js.js
+++ b/lib/extractors/js.js
@@ -10,8 +10,11 @@ function transform(src, opts, fn) {
         opts = {};
     }
 
-    opts = _.extend({ecmaVersion: 6}, opts);
-    return falafel(src, opts, fn);
+    opts.parserOptions = _.extend({}, {
+        ecmaVersion: 6
+    }, opts.parserOptions);
+
+    return falafel(src, opts.parserOptions, fn);
 }
 
 
@@ -38,7 +41,9 @@ function yoink_members(src, opts) {
 function gather(src, opts) {
     var matches = [];
 
-    opts = _.extend({}, { locations: true }, opts);
+    opts.parserOptions = _.extend({}, {
+        locations: true
+    }, opts.parserOptions);
 
     transform(src, opts, function(node) {
         if (match(node, opts)) {

--- a/test/extractors/js.test.js
+++ b/test/extractors/js.test.js
@@ -172,6 +172,33 @@ describe("jspot.extractors:js", function() {
             }]);
     });
 
+    it("should work allow overriding parser options", function() {
+        var testOptions = {
+            filename: 'foo.js',
+            source: "gettext('foobar');"
+        };
+
+        extractor(testOptions);
+
+        assert.deepEqual(testOptions.parserOptions, {
+            ecmaVersion: 6,
+            locations: true
+        });
+
+        testOptions.parserOptions = {
+            ecmaVersion: 5,
+            hello: 'world'
+        };
+
+        extractor(testOptions);
+
+        assert.deepEqual(testOptions.parserOptions, {
+            ecmaVersion: 5,
+            locations: true,
+            hello: 'world'
+        });
+    });
+
     describe("gettext", function() {
         it("should extract member calls", function() {
             assert.deepEqual(


### PR DESCRIPTION
Hello again,

I hope PR's are welcome; I was experimenting with JSPot a bit more after you very kindly updated the code base to handle ES2015 source files. During this experimenting I hit a problem where I needed to set more options for falafel / acorn that your current option (`ecmaVersion`), however, no other setting I applied seemed to be getting used.

I did some digging for an hour or so through your code base and realised that `transform` can sometimes be called without the options argument meaning at times it'll be called and ignore any settings you've supplied. `transform` seems to get called once without options right from launch and it seems to be `yoink_members` which does the calling.

You'll know the code base better than I do and the implications of my proposed changes, but in this PR I'm merely updating `yoink_members` method so it respects options that had been passed through to it. I'm also updating the `gather` method which was also passing options through to `transform` but wasn't extending any set by the user.

Have a look and see what you think!

Anthony