### PR TITLE
Conflict when same reference for a singular & a plural

### DIFF
--- a/lib/pot.js
+++ b/lib/pot.js
@@ -27,14 +27,23 @@ function add_to_pots(pots, text, opts) {
     var translations = pot.translations[text.context] || {};
     pot.translations[text.context] = translations;
 
+    add_to_translations(translations, text, opts);
+}
+
+
+function add_to_translations(translations, text, opts) {
     // NOTE: we currently ignore `text.category`, since Jed ignores this, and
     // since many deem the category modifier unnecessary. This may change.
     var translation = translations[text.key];
+
     if (!translation) {
         translations[text.key] = new_translation(text, opts);
     }
+    else if (!translation.msgid_plural && text.plural) {
+        translations[text.key] = replace_translation(translation, text, opts);
+    }
     else {
-        add_to_translation(translation, text, opts);
+        add_translation_reference(translation, translation_reference(text));
     }
 }
 
@@ -75,13 +84,28 @@ function new_translation(text, opts) {
 }
 
 
-function add_to_translation(translation, text, opts) {
-    var reference = translation_reference(text);
+function replace_translation(old, text, opts) {
+    var translation = new_translation(text, opts);
+    clear_translation_reference(translation);
+    add_translation_reference(translation, old.comments.reference);
+    add_translation_reference(translation, translation_reference(text));
+    return translation;
+}
+
+
+function clear_translation_reference(translation) {
+    translation.comments.reference = '';
+}
+
+
+function add_translation_reference(translation, reference) {
     if (translation.comments.reference.indexOf(reference) < 0) {
         translation.comments.reference = [
             translation.comments.reference,
             reference
-        ].join(' ');
+        ]
+        .join(' ')
+        .trim();
     }
 }
 

--- a/test/pot.test.js
+++ b/test/pot.test.js
@@ -222,7 +222,7 @@ describe("jspot.pot", function() {
         };
 
         jspot.pot({
-            pots:pots,
+            pots: pots,
             extracts: [{
                 key: 'foo',
                 plural: null,
@@ -238,6 +238,44 @@ describe("jspot.pot", function() {
             msgstr: [''],
             msgctxt: '',
             comments: {reference: 'lamb.js:3 ham.js:1'}
+        });
+    });
+
+    it("should replace singular translations with plural translations",
+    function() {
+        var pots = {
+            messages: {
+                translations: {
+                    '': {
+                        foo: {
+                            msgid: 'foo',
+                            msgstr: [''],
+                            msgctxt: '',
+                            comments: {reference: 'ham.js:1'}
+                        }
+                    },
+                }
+            }
+        };
+
+        jspot.pot({
+            pots: pots,
+            extracts: [{
+                key: 'foo',
+                plural: 'foos',
+                context: '',
+                domain: 'messages',
+                line: 1,
+                filename: 'lamb.js'
+            }]
+        });
+
+        assert.deepEqual(pots.messages.translations[''].foo, {
+            msgid: 'foo',
+            msgid_plural: 'foos',
+            msgstr: ['', ''],
+            msgctxt: '',
+            comments: {reference: 'ham.js:1 lamb.js:1'}
         });
     });
 });


### PR DESCRIPTION
Hi, long time no see ;)

I found a nasty behaviour when using gettext for a single word, and then ngettext for the same word. Example: 

```
gettext.ngettext('foo', 'foos', 1);
gettext('foo');
```

Only the singular form appear in the messages.pot

```
msgid "foo"
msgstr ""
```

Maybe it's "normal" because we cannot have twice the same msg_id, but if we have to choose one, would it be more correct to set the plural form in the messages.pot rather than the singular?