### PR TITLE
Add support for template literal

### DIFF
--- a/lib/extractors/js.js
+++ b/lib/extractors/js.js
@@ -3,6 +3,8 @@ var vm = require('vm');
 var falafel = require('falafel');
 var gettext = require('../gettext');
 
+var templateLiteralRE = /^`(.*)`$/;
+
 
 function transform(src, opts, fn) {
     if (typeof opts == 'function')  {
@@ -20,6 +22,7 @@ function transform(src, opts, fn) {
 
 function extract(opts) {
     var src = yoink_members(opts.source, opts);
+    src = yoink_tpl_string(src, opts);
 
     return gather(src, opts).map(function(node) {
         return run(node, opts);
@@ -33,6 +36,23 @@ function yoink_members(src, opts) {
     return transform(src, opts, function(node) {
         if (is_member(node, opts)) {
             node.parent.update(node.source());
+        }
+    }).toString();
+}
+
+
+function yoink_tpl_string(src, opts) {
+    opts = _.extend({}, opts);
+
+    return transform(src, opts, function(node) {
+        if (node.type === 'TemplateLiteral') {
+            var source = node.source();
+            if (source) {
+                source = source.replace(templateLiteralRE, function(_, content) {
+                    return "'" + content + "'";
+                });
+                node.update(source);
+            }
         }
     }).toString();
 }

--- a/test/extractors/js.test.js
+++ b/test/extractors/js.test.js
@@ -172,6 +172,22 @@ describe("jspot.extractors:js", function() {
             }]);
     });
 
+    it("should not try to eval template literal", function() {
+        assert.deepEqual(
+            extractor({
+                filename: 'foo.js',
+                source: "var msg = gettext.ngettext(`${count} mississippi`, `${count} mississippis`, count);"
+            }), [{
+                key: '${count} mississippi',
+                plural: '${count} mississippis',
+                domain: 'messages',
+                context: '',
+                category: null,
+                line: 1,
+                filename: 'foo.js',
+            }]);
+    });
+
     it("should work allow overriding parser options", function() {
         var testOptions = {
             filename: 'foo.js',


### PR DESCRIPTION
By preventing those being evaluated as such in vm because it's impossible to the vm to have the runtime context.

You might want to merge #45 1st even if it's not mandatory.