### PR TITLE
Fixes issue with template literal and simple quote

### DIFF
--- a/lib/extractors/js.js
+++ b/lib/extractors/js.js
@@ -4,6 +4,7 @@ var falafel = require('falafel');
 var gettext = require('../gettext');
 
 var templateLiteralRE = /^`(.*)`$/;
+var simpleQuoteRE = /'/g;
 
 
 function transform(src, opts, fn) {
@@ -47,7 +48,7 @@ function yoink_tpl_string(src, opts) {
             var source = node.source();
             if (source) {
                 source = source.replace(templateLiteralRE, function(_, content) {
-                    return "'" + content + "'";
+                    return "'" + content.replace(simpleQuoteRE, "\\'") + "'";
                 });
                 node.update(source);
             }

--- a/test/extractors/js.test.js
+++ b/test/extractors/js.test.js
@@ -188,6 +188,22 @@ describe("jspot.extractors:js", function() {
             }]);
     });
 
+    it("should not fail miserably when template literal contains simple quote", function() {
+        assert.deepEqual(
+            extractor({
+                filename: 'foo.js',
+                source: "{test: `bar and ${this.foo || ''} are forever`}"
+            }), []);
+    });
+
+    it("should not fail miserably when template literal contains another template literal", function() {
+        assert.deepEqual(
+            extractor({
+                filename: 'foo.js',
+                source: "{test: `var and ${this.foos.map(l => `${f.toLowerCase()}-suffixed`)}`}"
+            }), []);
+    });
+
     it("should work allow overriding parser options", function() {
         var testOptions = {
             filename: 'foo.js',


### PR DESCRIPTION
Sorry @justinvdm I let an issue with my last commit. I replaced template literal by string using simple quote without escaping potential simple quote already inside the template literal.